### PR TITLE
fix(deps): fix missing peer dependency for nestjs core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
         "cache-manager": "<=5",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "cache-manager": "<=5",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^7.0.0"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When this package is used with Yarn v3, we receive an error saying this package doesn't include @nestjs/core directly, causing an ambiguous import.

<img width="1256" alt="Screenshot 2023-06-22 at 11 19 37 AM" src="https://github.com/nestjs/cache-manager/assets/3953314/203138dc-7260-4e51-831d-df5921c98abd">


Issue Number: N/A

## What is the new behavior?
Works properly with Yarn v3 and there is no error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Workaround is to add the following to `.yarnrc.yml`:
```yml
packageExtensions:
  "@nestjs/cache-manager@*":
    peerDependencies:
      "@nestjs/core": ^9 || ^10
```
