### PR TITLE
chore(peer dependancies): fix required cache-manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.0 || ^10.0.0",
     "@nestjs/core": "^9.0.0 || ^10.0.0",
-    "cache-manager": "<=5",
+    "cache-manager": ">=5",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^7.0.0"
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features): N.A
- [x] Docs have been added / updated (for bug fixes / features): N.A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: fix inconsistency of cache-manager version between dev and peer dependencies requirements

## What is the current behavior?
- In the dev dependencies, the required version of `cache-manager` is `5.2.3`
- In the peer dependencies, the required version of `cache-manager` is `<=5`
- This makes it inconsistent, since the version used in dev is not even accepted as a version of peer dependencies (`5.2.3` does not satisfy `<=5`)
- This results in warnings when package is installed

## What is the new behavior?
We change the peer dependencies requirement to `>=5` to make consistency between the dev dependencies and peer dependencies.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
