### PR TITLE
fix(cache-manager): do not mutate ttl of default cache options

### DIFF
--- a/lib/cache.providers.ts
+++ b/lib/cache.providers.ts
@@ -2,7 +2,7 @@ import { Provider } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { CACHE_MANAGER } from './cache.constants';
 import { MODULE_OPTIONS_TOKEN } from './cache.module-definition';
-import { defaultCacheOptions } from './default-options';
+import { defaultCacheOptions as defaultCacheOptionsOrigin } from './default-options';
 import {
   CacheManagerOptions,
   CacheStore,
@@ -17,6 +17,7 @@ export function createCacheManager(): Provider {
   return {
     provide: CACHE_MANAGER,
     useFactory: async (options: CacheManagerOptions) => {
+      const defaultCacheOptions = { ...defaultCacheOptionsOrigin };
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
For Cache Manager v5 or greater: When multiple cache managers are created without specifying TTL in the options, every new instance would have a default TTL 1000 times greater than the previous one.
Reason is that the imported `defaultCacheOptions` is mutated in `createCacheManager`.
https://github.com/nestjs/cache-manager/blob/13c774a16198dd3b5337e017e60afa125513987c/lib/cache.providers.ts#L37

Issue Number: N/A


## What is the new behavior?
Default TTL is the same in every new cache manager instance.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
