### PR TITLE
feat(cache-manager): log detailed error when set cache key fails

### DIFF
--- a/lib/interceptors/cache.interceptor.ts
+++ b/lib/interceptors/cache.interceptor.ts
@@ -86,6 +86,7 @@ export class CacheInterceptor implements NestInterceptor {
           } catch (err) {
             Logger.error(
               `An error has occurred when inserting "key: ${key}", "value: ${response}"`,
+              err.stack,
               'CacheInterceptor',
             );
           }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #231


## What is the new behavior?
In case setting the cache fails, the error stack trace is logged giving details about what caused the problem, for example:

<img width="954" alt="Screenshot 2023-12-12 at 15 52 54" src="https://github.com/nestjs/cache-manager/assets/78625018/83f31a4b-6237-4542-a7b2-17e866d05b2c">

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
