### PR TITLE
feat: expose cache manager alias provider `Cache` class with same as the interface from `cache-manager`

### DIFF
--- a/lib/cache.module.ts
+++ b/lib/cache.module.ts
@@ -1,4 +1,5 @@
 import { DynamicModule, Module } from '@nestjs/common';
+import type { Cache as CoreCache } from 'cache-manager'
 import { CACHE_MANAGER } from './cache.constants';
 import { ConfigurableModuleClass } from './cache.module-definition';
 import { createCacheManager } from './cache.providers';
@@ -8,6 +9,15 @@ import {
 } from './interfaces/cache-module.interface';
 
 /**
+ * This is just the same as the `Cache` interface from `cache-manager` but you can
+ * use this as a provider token as well.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export abstract class Cache {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface Cache extends CoreCache {}
+
+/**
  * Module that provides Nest cache-manager.
  *
  * @see [Caching](https://docs.nestjs.com/techniques/caching)
@@ -15,8 +25,14 @@ import {
  * @publicApi
  */
 @Module({
-  providers: [createCacheManager()],
-  exports: [CACHE_MANAGER],
+  providers: [
+    createCacheManager(),
+    {
+      provide: Cache,
+      useExisting: CACHE_MANAGER,
+    }
+  ],
+  exports: [CACHE_MANAGER, Cache],
 })
 export class CacheModule extends ConfigurableModuleClass {
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,
-    "removeComments": true,
+    "removeComments": false,
     "noLib": false,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #253


## What is the new behavior?

1. no need to use `@Inject(CACHE_MANAGER)` anymore
2. no need to import `Cache` from another package. Always use the `@nestjs/cache-manager` one

![image](https://github.com/nestjs/cache-manager/assets/13461315/0a99ef48-cadf-4280-94cd-f0a96e38d97b)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
