### PR TITLE
fix(type): CacheModuleAsyncOptions

### DIFF
--- a/lib/interfaces/cache-module.interface.ts
+++ b/lib/interfaces/cache-module.interface.ts
@@ -1,18 +1,21 @@
 import { ConfigurableModuleAsyncOptions, Provider, Type } from '@nestjs/common';
 import { CacheManagerOptions } from './cache-manager.interface';
 
-export type CacheModuleOptions<
+export type CacheOptions<
   StoreConfig extends Record<any, any> = Record<string, any>,
 > =
   // Store-specific configuration takes precedence over cache module options due
   // to how `createCacheManager` is implemented.
-  CacheManagerOptions &
-    StoreConfig & {
-      /**
-       * If "true', register `CacheModule` as a global module.
-       */
-      isGlobal?: boolean;
-    };
+  CacheManagerOptions & StoreConfig;
+
+export type CacheModuleOptions<
+  StoreConfig extends Record<any, any> = Record<string, any>,
+> = CacheOptions<StoreConfig> & {
+  /**
+   * If "true', register `CacheModule` as a global module.
+   */
+  isGlobal?: boolean;
+};
 
 /**
  * Interface describing a `CacheOptionsFactory`.  Providers supplying configuration
@@ -26,8 +29,8 @@ export interface CacheOptionsFactory<
   StoreConfig extends Record<any, any> = Record<string, any>,
 > {
   createCacheOptions():
-    | Promise<CacheModuleOptions<StoreConfig>>
-    | CacheModuleOptions<StoreConfig>;
+    | Promise<CacheOptions<StoreConfig>>
+    | CacheOptions<StoreConfig>;
 }
 
 /**
@@ -40,7 +43,7 @@ export interface CacheOptionsFactory<
 export interface CacheModuleAsyncOptions<
   StoreConfig extends Record<any, any> = Record<string, any>,
 > extends ConfigurableModuleAsyncOptions<
-    CacheModuleOptions<StoreConfig>,
+    CacheOptions<StoreConfig>,
     keyof CacheOptionsFactory
   > {
   /**
@@ -59,9 +62,7 @@ export interface CacheModuleAsyncOptions<
    */
   useFactory?: (
     ...args: any[]
-  ) =>
-    | Promise<CacheModuleOptions<StoreConfig>>
-    | CacheModuleOptions<StoreConfig>;
+  ) => Promise<CacheOptions<StoreConfig>> | CacheOptions<StoreConfig>;
   /**
    * Dependencies that a Factory may inject.
    */


### PR DESCRIPTION
Reused type CacheModuleOptions causing isGlobal to leak incorrectly into async options.

https://github.com/nestjs/cache-manager/issues/349

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
isGlobal incorrectly appears in the config options for CacheModuleAsyncOptions

Issue Number: https://github.com/nestjs/cache-manager/issues/349


## What is the new behavior?
isGlobal is removed from the type

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
