### PR TITLE
feat(cache-manager): Support refresh cache keys in background options

### DIFF
--- a/lib/interfaces/cache-manager.interface.ts
+++ b/lib/interfaces/cache-manager.interface.ts
@@ -82,5 +82,15 @@ export interface CacheManagerOptions {
    * Maximum number of responses to store in the cache.  Defaults to 100.
    */
   max?: number;
+  /**
+   * optional, if refreshThreshold is set and after retrieving a value from cache the TTL will be checked.
+   * If the remaining TTL is less than refreshThreshold, the system will update the value asynchronously
+   */
+  refreshThreshold?: number;
+  /**
+   * optional, but if not set, background refresh error will be an unhandled
+   * promise rejection, which might crash your node process
+   */
+  onBackgroundRefreshError?: (error: any) => void;
   isCacheableValue?: (value: any) => boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #474

## What is the new behavior?

Cache Manager  `refreshThreshold` and `onBackgroundRefreshError` option can be used in nestjs@cache-manager.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
