### PR TITLE
fix: Use default import of Keyv to avoid CJS compilation error

### DIFF
--- a/lib/cache.providers.ts
+++ b/lib/cache.providers.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@nestjs/common';
 import { createCache } from 'cache-manager';
-import { Keyv, KeyvStoreAdapter } from 'keyv';
+import Keyv, { type KeyvStoreAdapter } from 'keyv';
 import { CACHE_MANAGER } from './cache.constants';
 import { MODULE_OPTIONS_TOKEN } from './cache.module-definition';
 import { CacheManagerOptions } from './interfaces/cache-manager.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When compiled to CommonJS, `import { Keyv } from 'keyv'` results in references to `keyv_1.Keyv` instead of `keyv_1.default`. This triggers a runtime `TypeError` (`Right-hand side of 'instanceof' is not an object`) when checking `store instanceof Keyv`.

## What is the new behavior?

- Changes the import statement in `cache-manager` to `import Keyv from 'keyv'`.
- Ensures `store instanceof Keyv` works correctly in CommonJS environments.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This approach aligns with the recommended usage in the official Keyv docs. It prevents compilation issues under CommonJS and maintains full compatibility with existing usage in NestJS.