### PR TITLE
feat: allow cache-key factory to be async

### DIFF
--- a/lib/decorators/cache-key.decorator.ts
+++ b/lib/decorators/cache-key.decorator.ts
@@ -1,7 +1,9 @@
 import { ExecutionContext, SetMetadata } from '@nestjs/common';
 import { CACHE_KEY_METADATA } from '../cache.constants';
 
-export type CacheKeyFactory = (ctx: ExecutionContext) => string;
+export type CacheKeyFactory = (
+  ctx: ExecutionContext,
+) => string | Promise<string | undefined> | undefined;
 
 /**
  * Decorator that sets the caching key used to store/retrieve cached items for


### PR DESCRIPTION
Builds on @ivanfmn's work and allows the cache key factory to be an async function.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
* Updates the CacheKeyFactory type to allow returning either a key or a promise.
* Updates the CacheInterceptor to await the cache key factory when necessary.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
