### PR TITLE
docs(cache-ttl): clarify that ttl is in milliseconds

### DIFF
--- a/lib/decorators/cache-ttl.decorator.ts
+++ b/lib/decorators/cache-ttl.decorator.ts
@@ -7,9 +7,9 @@ export type CacheTTLFactory = (
 /**
  * Decorator that sets the cache ttl setting the duration for cache expiration.
  *
- * For example: `@CacheTTL(5)`
+ * For example: `@CacheTTL(5000)`
  *
- * @param ttl number set the cache expiration time
+ * @param ttl number set the cache expiration time, in milliseconds
  *
  * @see [Caching](https://docs.nestjs.com/techniques/caching)
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: doc

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The previous JSDoc didn't mention a unit, and the `@CacheTTL(5)` example read like seconds.
Clarifies in the `@CacheTTL()` JSDoc that the ttl value is in **milliseconds**, 
and updates the example from `@CacheTTL(5)` to `@CacheTTL(5000)`.
Docs-only change, no behavior affected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
